### PR TITLE
Fix toast removal timing

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -9,7 +9,8 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+// Length of time before a toast is automatically removed (in ms)
+const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- reduce toast auto-removal delay to 5 seconds

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683b6b05c2a483278c8db02e00d25779