### PR TITLE
Add checkout API and post order

### DIFF
--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  try {
+    const data = await req.json();
+    console.log('Checkout payload', data);
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    return NextResponse.json({ success: false }, { status: 500 });
+  }
+}

--- a/src/components/CartCheckoutSection.tsx
+++ b/src/components/CartCheckoutSection.tsx
@@ -23,20 +23,31 @@ export default function CartCheckoutSection({ cart, updateQuantity, removeFromCa
   const [formValid, setFormValid] = useState(false);
 
   useEffect(() => {
-    const emailRegex = /\S+@\S+\.\S+/;
-    const phoneRegex = /^\+?\d{7,15}$/;
-    setFormValid(
-      fullName.trim().length > 0 &&
-        (emailRegex.test(contact) || phoneRegex.test(contact)) &&
-        cart.length > 0
-    );
+    const contactIsValid =
+      /\S+@\S+\.\S+/.test(contact) || /^\+?\d{7,15}$/.test(contact);
+    const nameIsValid = fullName.trim().length > 0;
+    setFormValid(nameIsValid && contactIsValid && cart.length > 0);
   }, [fullName, contact, cart]);
 
-  const handlePlaceOrder = (e: React.FormEvent) => {
+  const handlePlaceOrder = async (e: React.FormEvent) => {
     e.preventDefault();
-    alert(
-      `Order placed!\nName: ${fullName}\nContact: ${contact}\nNotes: ${notes}\nItems: ${cart.length}\nTotal: $${totalPrice.toFixed(2)}`
-    );
+    const payload = {
+      cart,
+      fullName,
+      contact,
+      notes,
+      total: totalPrice,
+    };
+    const res = await fetch('/api/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (res.ok) {
+      alert('Order received!');
+    } else {
+      alert('There was an error placing your order.');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- recalc form validity when checkout inputs change
- post order data to `/api/checkout`
- stub new checkout endpoint

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck` *(fails: cannot find @heroicons/react types)*

------
https://chatgpt.com/codex/tasks/task_e_683b84a17c788327afa5829a7ea62d96