### PR TITLE
Fix: Correct Header component import path in HomePage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client"; 
 import { useState } from "react";
-import Header from "../src/components/Header";
+import Header from "@/components/Header";
 import HeroSection from "../src/components/HeroSection";
 import FlavorsSection from "../src/components/FlavorsSection";
 import CartCheckoutSection from "../src/components/CartCheckoutSection";


### PR DESCRIPTION
The Header component was being imported with an incorrect relative path in `app/page.tsx`, leading to a runtime error. This commit corrects the import path to use the `@/` alias, resolving the 'Element type is invalid' error.