### PR TITLE
Fix: Update Heroicons imports in Header component

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { ShoppingCartIcon, MenuIcon, XIcon } from '@heroicons/react/outline';
+import { ShoppingCartIcon, Bars3Icon as MenuIcon, XMarkIcon as XIcon } from '@heroicons/react/24/outline';
 import { useState } from 'react';
 
 interface HeaderProps {


### PR DESCRIPTION
The Header component was using outdated import paths for Heroicons v1, while the project has Heroicons v2 installed. This caused an error "Element type is invalid: expected a string ... but got: undefined" because the icons were not being loaded correctly.

This commit updates the import paths to use the Heroicons v2 syntax (specifically `@heroicons/react/24/outline`). It also aliases `Bars3Icon` to `MenuIcon` and `XMarkIcon` to `XIcon` to maintain compatibility with the existing component code that uses these names.

This resolves the rendering error for the Header component.