### PR TITLE
Remove Order Now nav link

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -37,7 +37,6 @@ export default function Header({ cartCount }: HeaderProps) {
 
         <nav className="hidden md:flex space-x-6 items-center">
           <a href="#flavors" className="font-medium text-charcoal hover:text-brick">Our Breads</a>
-          <a href="#checkout" className="font-medium text-charcoal hover:text-brick">Order Now</a>
           <Link href="#checkout" className="relative">
             <ShoppingCartIcon className="h-6 w-6 text-charcoal hover:text-brick" />
             {cartCount > 0 && (
@@ -59,7 +58,6 @@ export default function Header({ cartCount }: HeaderProps) {
         <nav className="md:hidden border-t border-ochre bg-parchment-light py-2">
           <ul className="flex flex-col space-y-2 px-4">
             <li><a href="#flavors" onClick={closeMenu} className="block py-2 font-medium text-charcoal hover:text-brick">Our Breads</a></li>
-            <li><a href="#checkout" onClick={closeMenu} className="block py-2 font-medium text-charcoal hover:text-brick">Order Now</a></li>
             <li>
               <Link
                 href="#checkout"

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -20,9 +20,6 @@ export function AppHeader({ cartItemCount }: AppHeaderProps) {
           <Link href="#flavors" className="text-sm font-medium text-foreground hover:text-primary transition-colors">
             Our Breads
           </Link>
-          <Link href="#order" className="text-sm font-medium text-foreground hover:text-primary transition-colors">
-            Order Now
-          </Link>
           <Link href="#cart" className="relative flex items-center text-sm font-medium text-foreground hover:text-primary transition-colors">
             <ShoppingCart className="h-6 w-6" />
             {cartItemCount > 0 && (


### PR DESCRIPTION
## Summary
- remove "Order Now" navigation links

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_683b921b08a88327a305b9463b2b6d4f