### PR TITLE
Remove Order for Pickup link from hero

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -23,12 +23,6 @@ export default function HeroSection() {
           >
             Discover Our Breads
           </a>
-          <a
-            href="#checkout"
-            className="inline-block px-6 py-3 border-2 border-brick text-brick font-semibold rounded-md text-sm hover:bg-brick hover:text-parchment transition"
-          >
-            Order for Pickup
-          </a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- remove `Order for Pickup` CTA from the hero section

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_683b92507a18832792f0adb0d716ba5b