### PR TITLE
Implement cart flavor limit

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -51,7 +51,7 @@ export default function HomePage() {
       <Header cartCount={cartCount} totalPrice={totalPrice} />
       <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
         <HeroSection />
-        <FlavorsSection addToCart={addToCart} />
+        <FlavorsSection cart={cart} addToCart={addToCart} />
         <CartCheckoutSection
           cart={cart}
           updateQuantity={updateQuantity}


### PR DESCRIPTION
## Summary
- ensure FlavorsSection knows current cart and enforces a 5 loaf max per flavor
- show warnings and disable controls when the limit is reached
- update HomePage to pass cart into FlavorsSection

## Testing
- `npm run typecheck` *(fails: `npm` not found)*
- `npm run lint` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b968279b883278b8b4b986bc5e09e