### PR TITLE
Add favicon metadata to layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Head from "next/head";
 import "./globals.css";
 import { Toaster } from "@/components/ui/toaster"; // Import Toaster
 
@@ -15,7 +16,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <head>
+      <Head>
+        <link rel="icon" href="/favicon.ico" />
+        <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+        <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+        <meta name="theme-color" content="#F9F4E9" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
           rel="preconnect"
@@ -26,7 +31,7 @@ export default function RootLayout({
           href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700&family=Montserrat:wght@400;500;600&display=swap"
           rel="stylesheet"
         />
-      </head>
+      </Head>
       <body className="font-body antialiased">
         {children}
         <Toaster />


### PR DESCRIPTION
## Summary
- include `Head` element in `app/layout.tsx`
- add favicon links and theme color metadata

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683b9b1cffb88327ad0d6d81c11ea41f