### PR TITLE
Remove bread icons from daily bakes cards

### DIFF
--- a/src/components/FlavorsSection.tsx
+++ b/src/components/FlavorsSection.tsx
@@ -203,8 +203,7 @@ export default function FlavorsSection({ cart, addToCart }: FlavorsSectionProps)
               />
             </div>
             <div className="p-4 flex flex-col flex-grow">
-              <div className="flex items-center space-x-2">
-                {flavor.icon}
+              <div className="mb-2">
                 <h3 className="font-heading text-xl text-brick">{flavor.name}</h3>
               </div>
               <p className="mt-2 text-charcoal text-sm flex-grow">{flavor.description}</p>

--- a/src/components/flavors-section.tsx
+++ b/src/components/flavors-section.tsx
@@ -35,8 +35,7 @@ export function FlavorsSection({ onAddToCart }: FlavorsSectionProps) {
                 </div>
               </CardHeader>
               <CardContent className="flex-grow p-6">
-                <div className="flex items-center mb-3">
-                  {flavor.Icon && <flavor.Icon className="h-7 w-7 text-accent mr-3" />}
+                <div className="mb-3">
                   <CardTitle className="font-headline text-2xl text-primary">{flavor.name}</CardTitle>
                 </div>
                 <CardDescription className="text-foreground text-base">

--- a/src/config/breads.ts
+++ b/src/config/breads.ts
@@ -1,5 +1,4 @@
 import type { BreadFlavor } from '@/types';
-import { Wheat, Flame, Leaf } from 'lucide-react';
 
 export const BREAD_FLAVORS: BreadFlavor[] = [
   {
@@ -8,7 +7,6 @@ export const BREAD_FLAVORS: BreadFlavor[] = [
     description: 'A classic, tangy loaf with a satisfyingly chewy crust and open crumb. Perfect for any occasion.',
     imageSrc: 'https://placehold.co/600x400.png',
     imageHint: 'sourdough bread artisan',
-    Icon: Wheat,
     price: 10,
   },
   {
@@ -17,7 +15,6 @@ export const BREAD_FLAVORS: BreadFlavor[] = [
     description: 'A fiery kick of jalapeños perfectly balanced with pockets of sharp, melted cheddar cheese.',
     imageSrc: 'https://placehold.co/600x400.png',
     imageHint: 'jalapeno cheese bread',
-    Icon: Flame,
     price: 10,
   },
   {
@@ -26,7 +23,6 @@ export const BREAD_FLAVORS: BreadFlavor[] = [
     description: 'Aromatic rosemary and sweet, mellow garlic confit infused into a rustic, flavorful loaf.',
     imageSrc: 'https://placehold.co/600x400.png',
     imageHint: 'rosemary garlic bread',
-    Icon: Leaf,
     price: 10,
   },
 ];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,12 +1,9 @@
-import type { LucideIcon } from 'lucide-react';
-
 export interface BreadFlavor {
   id: string;
   name: string;
   description: string;
   imageSrc: string;
   imageHint: string;
-  Icon?: LucideIcon | React.ElementType; // Allow LucideIcon or custom SVG component
   price: number;
 }
 


### PR DESCRIPTION
## Summary
- remove icon rendering from daily bakes card components
- remove icon fields in bread configuration and types

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_683b9b5bba008327a091d0fb76e8db9c