### PR TITLE
Update bread flavor limit

### DIFF
--- a/src/components/FlavorsSection.tsx
+++ b/src/components/FlavorsSection.tsx
@@ -155,7 +155,8 @@ export default function FlavorsSection({ cart, addToCart }: FlavorsSectionProps)
     const found = cart.find((ci) => ci.id === flavorId);
     return found ? found.quantity : 0;
   };
-  const maxPerFlavor = 5;
+  // Maximum number of loaves a customer can purchase per flavor
+  const maxPerFlavor = 3;
 
   const [quantities, setQuantities] = useState<Record<string, number>>({
     "pure-hearth-loaf": 1,
@@ -231,7 +232,7 @@ export default function FlavorsSection({ cart, addToCart }: FlavorsSectionProps)
                         : ""
                     }`}
                   >
-                    {[...Array(5)].map((_, i) => {
+                    {[...Array(maxPerFlavor)].map((_, i) => {
                       const n = i + 1;
                       return (
                         <option key={n} value={n} disabled={n > availableToAdd}>
@@ -256,7 +257,7 @@ export default function FlavorsSection({ cart, addToCart }: FlavorsSectionProps)
                     Limit Reached
                   </button>
                   <p className="mt-2 text-center text-red-600 text-sm">
-                    You’ve reached the 5-loaf limit for {flavor.name}.
+                    You’ve reached the 3-loaf limit for {flavor.name}.
                   </p>
                 </div>
               ) : (


### PR DESCRIPTION
## Summary
- reduce the maximum number of loaves per flavor to three
- reference the new limit when building the quantity selector and limit message

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_683b9b9959388327aa1b959c5dfd862f