### PR TITLE
Add simple blog generator and first posts

### DIFF
--- a/public/blog/5-tips-to-keep-bread-fresh/index.html
+++ b/public/blog/5-tips-to-keep-bread-fresh/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>5 Tips to Keep Your Artisan Bread Fresh in Yuma’s Heat</title>
+  <meta name="description" content="Learn how to store your loaf so it stays soft all week, even in desert temperatures.">
+</head>
+<body>
+<h1>5 Tips to Keep Your Artisan Bread Fresh in Yuma’s Heat</h1>
+<p><em>By Yuma Hearth Team on 2025-06-01</em></p>
+
+<p>Yuma’s scorching summers can make even the crustiest baguette go stale in no time. Keeping your artisan loaf fresh is an art in itself. Whether you’re new to baking or a seasoned shopper at your local farmers market, understanding how heat and humidity affect bread is crucial. Below we break down five essential tips to ensure every slice stays tender, flavorful, and delicious long after it leaves the oven.</p>
+
+<h2>1. Cool Completely Before Storage</h2>
+
+<p>One of the most common mistakes people make is wrapping bread while it’s still warm. When trapped, residual steam condenses inside your storage container or bag, producing unwanted moisture. This encourages mold and leaves the crust soggy instead of crisp. Allow your loaf to cool on a wire rack until the inside and outside reach room temperature. For a full-size boule, this could take up to two hours. Patience pays off—once cooled, your bread will hold up far better in a sealed environment.</p>
+
+<h2>2. Choose the Right Container</h2>
+
+<p>The container you select can either extend freshness or accelerate staleness. Avoid plastic whenever possible, as it traps moisture and softens the crust. A paper bag, linen bread bag, or even a clean cotton pillowcase provides just enough air circulation to keep the crumb moist without letting it dry out. In Yuma’s dry air, a cloth bag paired with a bread box is ideal. The box shields the loaf from direct sunlight while the breathable material prevents condensation. If you’re dealing with an especially crusty loaf, consider storing it cut-side down on a cutting board under a cotton towel—simple yet effective.</p>
+
+<img src="https://placehold.co/600x400/png?text=Fresh+Loaf" alt="Fresh loaf cooling" loading="lazy">
+
+<h2>3. Keep Bread in a Cool, Dark Spot</h2>
+
+<p>Direct heat is the enemy of fresh bread. Yuma kitchens can easily surpass eighty degrees, particularly during mid-afternoon. Find a shaded area—perhaps a pantry or cupboard away from appliances—to reduce exposure to heat and light. These elements speed up staling by drying the crumb. If your home routinely climbs into the nineties, don’t hesitate to refrigerate for short periods. Wrap the loaf tightly in a cloth and place it in the fridge to slow microbial growth. Just remember to bring the bread back to room temperature before serving; it will taste nearly as good as when first baked.</p>
+
+<h2>4. Slice as You Go</h2>
+
+<p>Every cut exposes the crumb to air, hastening staleness. Instead of slicing the entire loaf at once, cut only what you need. Store the remaining portion with the cut side down, either on your cutting board or within your chosen bag or box. If you freeze your bread for longer storage, pre-slice before freezing so you can thaw only the pieces you want. A sharp, serrated knife works best and keeps the crust intact.</p>
+
+<h2>5. Revive Day-Old Bread with a Light Reheat</h2>
+
+<p>Even when you follow all these steps, bread naturally loses a bit of moisture over time. Reviving it is as easy as a quick splash of water and a short toast in the oven. Lightly dampen the crust under running water—don’t soak it—then pop the loaf in a hot oven for five minutes. The steam rejuvenates the crumb, giving you a crisp exterior and soft interior as if it were freshly baked. Alternatively, wrap the loaf in foil and warm it at a lower temperature for ten minutes if you prefer a gentler crust.</p>
+
+<p>By implementing these simple practices, you can beat Yuma’s desert climate and keep your artisan bread tasting bakery fresh all week. Experiment with different storage methods to suit the specific bread you love, whether it’s a hearty whole wheat boule or an airy ciabatta. Most importantly, enjoy every bite knowing that your efforts—cooling properly, choosing breathable containers, storing in cool spaces, slicing judiciously, and reheating carefully—truly make a difference.</p>
+
+<p>Even with meticulous care, you may still find yourself with leftover bread before the week is out. Don’t toss it—stale slices can be transformed into croutons, bread pudding, or homemade breadcrumbs. Simply cube or tear the extra pieces, toast them lightly, and store them in an airtight jar. These morsels add texture to salads and soups, making sure every loaf you buy is enjoyed to the last crumb. If you have more than you can use right away, freeze the pieces in a resealable bag, then crisp them in the oven when needed. This approach minimizes food waste and stretches your grocery budget.</p>
+
+<p>With a few small adjustments, you’ll discover that Yuma’s dry heat doesn’t have to shorten the life of your bread. By planning ahead, choosing smart storage solutions, and reviving loaves when necessary, you can savor the flavor of artisan baking long after purchase. Happy munching!</p>
+</body>
+</html>

--- a/public/blog/index.html
+++ b/public/blog/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Blog</title>
+</head>
+<body>
+<h1>Blog</h1>
+<ul>
+<li><h2><a href="5-tips-to-keep-bread-fresh/">5 Tips to Keep Your Artisan Bread Fresh in Yuma’s Heat</a></h2>
+<p>Yuma’s scorching summers can make even the crustiest baguette go stale in no time. Keeping your artisan loaf fresh is an art in itself. Whether you’re new to baking or...</p>
+<p><em>2025-06-01</em> <a href="5-tips-to-keep-bread-fresh/">Read More</a></p></li>
+<li><h2><a href="why-artisan-sourdough-gaining-popularity/">Why Artisan Sourdough Is Gaining Popularity</a></h2>
+<p>Artisan sourdough is more than just a passing fad. From family-run bakeries to high-end restaurants, sourdough’s tangy flavor and chewy texture have developed a loyal following. Its resurgence speaks to...</p>
+<p><em>2025-06-15</em> <a href="why-artisan-sourdough-gaining-popularity/">Read More</a></p></li>
+</ul>
+</body>
+</html>

--- a/public/blog/why-artisan-sourdough-gaining-popularity/index.html
+++ b/public/blog/why-artisan-sourdough-gaining-popularity/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Why Artisan Sourdough Is Gaining Popularity</title>
+  <meta name="description" content="Discover the reasons behind the rise of artisan sourdough and how this traditional loaf captured modern taste buds.">
+</head>
+<body>
+<h1>Why Artisan Sourdough Is Gaining Popularity</h1>
+<p><em>By Yuma Hearth Team on 2025-06-15</em></p>
+
+<p>Artisan sourdough is more than just a passing fad. From family-run bakeries to high-end restaurants, sourdough’s tangy flavor and chewy texture have developed a loyal following. Its resurgence speaks to broader movements in the culinary world: a renewed focus on fermented foods, a desire for natural ingredients, and a cultural push toward slowing down to appreciate craft. Understanding this trend means exploring not only the science of fermentation but also the stories and communities that surround each rustic loaf.</p>
+
+<h2>Return to Traditional Techniques</h2>
+
+<p>Modern industrial bread often relies on fast-rising commercial yeast. In contrast, artisan sourdough depends on a living culture of wild yeast and lactic acid bacteria. Bakers spend years nurturing these starters, sometimes handed down through generations. The long fermentation process breaks down gluten and contributes complex flavors you can’t achieve with instant yeast alone. It also brings a sense of heritage to the table, connecting people to ancient methods that have sustained civilizations for millennia.</p>
+
+<img src="https://placehold.co/600x400/png?text=Baker+Working" alt="Baker shaping dough" loading="lazy">
+
+<h2>Health Benefits Driving Demand</h2>
+
+<p>Sourdough fermentation not only intensifies flavor but can also make bread easier to digest. The natural acids help neutralize phytic acid, which is found in grains and can inhibit mineral absorption. Some studies suggest that long fermentation may lower the bread’s glycemic index, leading to more stable blood sugar levels. While not a cure-all, these health benefits appeal to consumers seeking foods that align with their wellness goals without sacrificing taste. In Yuma, where a vibrant community of health-conscious eaters thrives, these factors contribute heavily to sourdough’s popularity.</p>
+
+<h2>Flavor Complexity and Versatility</h2>
+
+<p>Artisan sourdough boasts a depth of flavor that mass-produced bread simply can’t replicate. From the gentle tang to the satisfying chew, each loaf tells a story of its starter culture and baking environment. Bakers tweak hydration levels, flour blends, and fermentation times to craft unique profiles—nutty, sweet, or strikingly sour. This versatility also extends to how people enjoy sourdough, from sandwiches to gourmet toast topped with local produce. As more consumers search for distinctive dining experiences, sourdough’s complex character keeps them coming back for more.</p>
+
+<h2>Community and Craftsmanship</h2>
+
+<p>Beyond taste and health, sourdough carries a sense of community. Many small bakeries embrace open-kitchen designs where customers witness the baking process firsthand. Workshops, classes, and social media groups encourage home bakers to share techniques and starter swaps. In Yuma, this camaraderie fosters lasting connections and local pride. It transforms a simple loaf into a centerpiece for neighborhood gatherings and farmers markets, creating a dialogue between artisan bakers and their patrons.</p>
+
+<h2>Sustainability and Local Flour</h2>
+
+<p>Interest in artisan sourdough also aligns with sustainable practices. Many bakers source flour from regional mills or farms that prioritize organic or regenerative agriculture. Local grains often have distinctive flavors, giving the bread terroir—much like wine or coffee. By purchasing sourdough made with nearby ingredients, consumers support local farmers and reduce the environmental impact associated with long-distance shipping. This commitment to sustainability resonates strongly in communities that value responsible food choices.</p>
+
+<h2>Social Media’s Role in Sourdough’s Rise</h2>
+
+<p>The visual appeal of crusty, scored loaves is undeniable. Platforms like Instagram and TikTok are filled with close-up crumb shots and time-lapse videos of dough rising. During the pandemic, many people took up home baking, sharing successes and failures online. This digital exposure demystified sourdough for a new generation of cooks. Even as normal routines resumed, interest remained high thanks to these online communities, which continue to celebrate the craft and inspire others to join in.</p>
+
+<h2>Final Thoughts</h2>
+
+<p>Artisan sourdough’s growing popularity is the result of multiple converging trends: an appreciation of traditional techniques, perceived health advantages, complex flavor, a sense of community, sustainable sourcing, and social media inspiration. Each loaf represents hours—sometimes days—of attentive preparation. It embodies the slower rhythms many crave in a fast-paced world. In Yuma and beyond, sourdough captures the spirit of craftsmanship and connection, turning a humble ingredient list of flour, water, and salt into a culinary experience that draws people together.</p>
+
+<p>The next time you bite into a slice of tangy, chewy sourdough, consider the story behind it. From the microscopic yeast that leavened the dough to the baker’s hands that shaped the loaf, you’re participating in a tradition that stretches back centuries. As more people discover the magic of artisan sourdough, its popularity will continue to rise—proof that good things truly come to those who take the time to let them develop.</p>
+
+<p>As local bakeries continue to innovate, expect to see new flavor combinations and grain varieties that push sourdough in exciting directions. Workshops and community bake days will further cement its role in Yuma’s food culture. Whether you’re a lifelong bread lover or just curious about the hype, there’s never been a better time to try artisan sourdough. Pair it with your favorite spreads, share it with friends, and celebrate the craftsmanship that turns a few simple ingredients into something truly memorable.</p>
+</body>
+</html>

--- a/scripts/generate_blog.py
+++ b/scripts/generate_blog.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Simple blog generator to convert Markdown posts into HTML."""
+
+import os
+import re
+from pathlib import Path
+
+SRC_DIR = Path('src/blog')
+OUT_DIR = Path('public/blog')
+
+
+def parse_front_matter(text: str):
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != '---':
+        return {}, text
+    fm_lines = []
+    i = 1
+    while i < len(lines):
+        if lines[i].strip() == '---':
+            break
+        fm_lines.append(lines[i])
+        i += 1
+    body = '\n'.join(lines[i + 1:])
+    fm = {}
+    for ln in fm_lines:
+        if ':' not in ln:
+            continue
+        key, val = ln.split(':', 1)
+        key = key.strip()
+        val = val.strip().strip('"')
+        if val.startswith('[') and val.endswith(']'):
+            items = [v.strip().strip('"') for v in val[1:-1].split(',') if v.strip()]
+            fm[key] = items
+        else:
+            fm[key] = val
+    return fm, body
+
+
+def md_to_html(md: str) -> str:
+    lines = md.splitlines()
+    html = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if line.startswith('# '):
+            html.append(f'<h1>{line[2:].strip()}</h1>')
+        elif line.startswith('## '):
+            html.append(f'<h2>{line[3:].strip()}</h2>')
+        elif line.startswith('### '):
+            html.append(f'<h3>{line[4:].strip()}</h3>')
+        elif re.match(r'!\[.*\]\(.*\)', line):
+            m = re.match(r'!\[(.*?)\]\((.*?)\)', line)
+            alt, src = m.groups()
+            html.append(f'<img src="{src}" alt="{alt}" loading="lazy">')
+        elif re.match(r'\d+\.\s', line):
+            html.append('<ol>')
+            while i < len(lines) and re.match(r'\d+\.\s', lines[i]):
+                item = re.sub(r'^\d+\.\s', '', lines[i])
+                html.append(f'<li>{item}</li>')
+                i += 1
+            html.append('</ol>')
+            continue
+        elif line.startswith('- '):
+            html.append('<ul>')
+            while i < len(lines) and lines[i].startswith('- '):
+                item = lines[i][2:]
+                html.append(f'<li>{item}</li>')
+                i += 1
+            html.append('</ul>')
+            continue
+        elif line.strip() == '':
+            html.append('')
+        else:
+            text = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', line)
+            text = re.sub(r'\*(.+?)\*', r'<em>\1</em>', text)
+            html.append(f'<p>{text}</p>')
+        i += 1
+    return '\n'.join(html)
+
+
+def build_post(md_path: Path):
+    text = md_path.read_text(encoding='utf-8')
+    fm, body = parse_front_matter(text)
+    slug = md_path.name.split('-', 3)[3].rsplit('.', 1)[0]
+    content_html = md_to_html(body)
+    out_dir = OUT_DIR / slug
+    out_dir.mkdir(parents=True, exist_ok=True)
+    html = f"""<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"UTF-8\">
+  <title>{fm.get('title', '')}</title>
+  <meta name=\"description\" content=\"{fm.get('description', '')}\">
+</head>
+<body>
+<h1>{fm.get('title', '')}</h1>
+<p><em>By {fm.get('author', '')} on {fm.get('date', '')}</em></p>
+{content_html}
+</body>
+</html>
+"""
+    (out_dir / 'index.html').write_text(html, encoding='utf-8')
+    return fm, body, slug
+
+
+def main():
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    posts = []
+    for md_file in sorted(SRC_DIR.glob('*.md')):
+        fm, body, slug = build_post(md_file)
+        posts.append({'fm': fm, 'body': body, 'slug': slug})
+
+    items_html = []
+    for p in posts:
+        words = p['body'].split()
+        excerpt = ' '.join(words[:30])
+        item = f"<h2><a href=\"{p['slug']}/\">{p['fm'].get('title','')}</a></h2>\n" \
+               f"<p>{excerpt}...</p>\n<p><em>{p['fm'].get('date','')}</em> <a href=\"{p['slug']}/\">Read More</a></p>"
+        items_html.append(f"<li>{item}</li>")
+
+    index_html = """<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"UTF-8\">
+  <title>Blog</title>
+</head>
+<body>
+<h1>Blog</h1>
+<ul>
+""" + '\n'.join(items_html) + "\n</ul>\n</body>\n</html>\n"
+
+    (OUT_DIR / 'index.html').write_text(index_html, encoding='utf-8')
+
+
+if __name__ == '__main__':
+    main()

--- a/src/blog/2025-06-01-5-tips-to-keep-bread-fresh.md
+++ b/src/blog/2025-06-01-5-tips-to-keep-bread-fresh.md
@@ -1,0 +1,37 @@
+---
+title: "5 Tips to Keep Your Artisan Bread Fresh in Yuma’s Heat"
+date: "2025-06-01"
+author: "Yuma Hearth Team"
+description: "Learn how to store your loaf so it stays soft all week, even in desert temperatures."
+tags: ["bread care", "Yuma", "artisan bread"]
+---
+
+Yuma’s scorching summers can make even the crustiest baguette go stale in no time. Keeping your artisan loaf fresh is an art in itself. Whether you’re new to baking or a seasoned shopper at your local farmers market, understanding how heat and humidity affect bread is crucial. Below we break down five essential tips to ensure every slice stays tender, flavorful, and delicious long after it leaves the oven.
+
+## 1. Cool Completely Before Storage
+
+One of the most common mistakes people make is wrapping bread while it’s still warm. When trapped, residual steam condenses inside your storage container or bag, producing unwanted moisture. This encourages mold and leaves the crust soggy instead of crisp. Allow your loaf to cool on a wire rack until the inside and outside reach room temperature. For a full-size boule, this could take up to two hours. Patience pays off—once cooled, your bread will hold up far better in a sealed environment.
+
+## 2. Choose the Right Container
+
+The container you select can either extend freshness or accelerate staleness. Avoid plastic whenever possible, as it traps moisture and softens the crust. A paper bag, linen bread bag, or even a clean cotton pillowcase provides just enough air circulation to keep the crumb moist without letting it dry out. In Yuma’s dry air, a cloth bag paired with a bread box is ideal. The box shields the loaf from direct sunlight while the breathable material prevents condensation. If you’re dealing with an especially crusty loaf, consider storing it cut-side down on a cutting board under a cotton towel—simple yet effective.
+
+![Fresh loaf cooling](https://placehold.co/600x400/png?text=Fresh+Loaf)
+
+## 3. Keep Bread in a Cool, Dark Spot
+
+Direct heat is the enemy of fresh bread. Yuma kitchens can easily surpass eighty degrees, particularly during mid-afternoon. Find a shaded area—perhaps a pantry or cupboard away from appliances—to reduce exposure to heat and light. These elements speed up staling by drying the crumb. If your home routinely climbs into the nineties, don’t hesitate to refrigerate for short periods. Wrap the loaf tightly in a cloth and place it in the fridge to slow microbial growth. Just remember to bring the bread back to room temperature before serving; it will taste nearly as good as when first baked.
+
+## 4. Slice as You Go
+
+Every cut exposes the crumb to air, hastening staleness. Instead of slicing the entire loaf at once, cut only what you need. Store the remaining portion with the cut side down, either on your cutting board or within your chosen bag or box. If you freeze your bread for longer storage, pre-slice before freezing so you can thaw only the pieces you want. A sharp, serrated knife works best and keeps the crust intact.
+
+## 5. Revive Day-Old Bread with a Light Reheat
+
+Even when you follow all these steps, bread naturally loses a bit of moisture over time. Reviving it is as easy as a quick splash of water and a short toast in the oven. Lightly dampen the crust under running water—don’t soak it—then pop the loaf in a hot oven for five minutes. The steam rejuvenates the crumb, giving you a crisp exterior and soft interior as if it were freshly baked. Alternatively, wrap the loaf in foil and warm it at a lower temperature for ten minutes if you prefer a gentler crust.
+
+By implementing these simple practices, you can beat Yuma’s desert climate and keep your artisan bread tasting bakery fresh all week. Experiment with different storage methods to suit the specific bread you love, whether it’s a hearty whole wheat boule or an airy ciabatta. Most importantly, enjoy every bite knowing that your efforts—cooling properly, choosing breathable containers, storing in cool spaces, slicing judiciously, and reheating carefully—truly make a difference.
+
+Even with meticulous care, you may still find yourself with leftover bread before the week is out. Don’t toss it—stale slices can be transformed into croutons, bread pudding, or homemade breadcrumbs. Simply cube or tear the extra pieces, toast them lightly, and store them in an airtight jar. These morsels add texture to salads and soups, making sure every loaf you buy is enjoyed to the last crumb. If you have more than you can use right away, freeze the pieces in a resealable bag, then crisp them in the oven when needed. This approach minimizes food waste and stretches your grocery budget.
+
+With a few small adjustments, you’ll discover that Yuma’s dry heat doesn’t have to shorten the life of your bread. By planning ahead, choosing smart storage solutions, and reviving loaves when necessary, you can savor the flavor of artisan baking long after purchase. Happy munching!

--- a/src/blog/2025-06-15-why-artisan-sourdough-gaining-popularity.md
+++ b/src/blog/2025-06-15-why-artisan-sourdough-gaining-popularity.md
@@ -1,0 +1,43 @@
+---
+title: "Why Artisan Sourdough Is Gaining Popularity"
+date: "2025-06-15"
+author: "Yuma Hearth Team"
+description: "Discover the reasons behind the rise of artisan sourdough and how this traditional loaf captured modern taste buds."
+tags: ["sourdough", "artisan bread", "trends"]
+---
+
+Artisan sourdough is more than just a passing fad. From family-run bakeries to high-end restaurants, sourdough’s tangy flavor and chewy texture have developed a loyal following. Its resurgence speaks to broader movements in the culinary world: a renewed focus on fermented foods, a desire for natural ingredients, and a cultural push toward slowing down to appreciate craft. Understanding this trend means exploring not only the science of fermentation but also the stories and communities that surround each rustic loaf.
+
+## Return to Traditional Techniques
+
+Modern industrial bread often relies on fast-rising commercial yeast. In contrast, artisan sourdough depends on a living culture of wild yeast and lactic acid bacteria. Bakers spend years nurturing these starters, sometimes handed down through generations. The long fermentation process breaks down gluten and contributes complex flavors you can’t achieve with instant yeast alone. It also brings a sense of heritage to the table, connecting people to ancient methods that have sustained civilizations for millennia.
+
+![Baker shaping dough](https://placehold.co/600x400/png?text=Baker+Working)
+
+## Health Benefits Driving Demand
+
+Sourdough fermentation not only intensifies flavor but can also make bread easier to digest. The natural acids help neutralize phytic acid, which is found in grains and can inhibit mineral absorption. Some studies suggest that long fermentation may lower the bread’s glycemic index, leading to more stable blood sugar levels. While not a cure-all, these health benefits appeal to consumers seeking foods that align with their wellness goals without sacrificing taste. In Yuma, where a vibrant community of health-conscious eaters thrives, these factors contribute heavily to sourdough’s popularity.
+
+## Flavor Complexity and Versatility
+
+Artisan sourdough boasts a depth of flavor that mass-produced bread simply can’t replicate. From the gentle tang to the satisfying chew, each loaf tells a story of its starter culture and baking environment. Bakers tweak hydration levels, flour blends, and fermentation times to craft unique profiles—nutty, sweet, or strikingly sour. This versatility also extends to how people enjoy sourdough, from sandwiches to gourmet toast topped with local produce. As more consumers search for distinctive dining experiences, sourdough’s complex character keeps them coming back for more.
+
+## Community and Craftsmanship
+
+Beyond taste and health, sourdough carries a sense of community. Many small bakeries embrace open-kitchen designs where customers witness the baking process firsthand. Workshops, classes, and social media groups encourage home bakers to share techniques and starter swaps. In Yuma, this camaraderie fosters lasting connections and local pride. It transforms a simple loaf into a centerpiece for neighborhood gatherings and farmers markets, creating a dialogue between artisan bakers and their patrons.
+
+## Sustainability and Local Flour
+
+Interest in artisan sourdough also aligns with sustainable practices. Many bakers source flour from regional mills or farms that prioritize organic or regenerative agriculture. Local grains often have distinctive flavors, giving the bread terroir—much like wine or coffee. By purchasing sourdough made with nearby ingredients, consumers support local farmers and reduce the environmental impact associated with long-distance shipping. This commitment to sustainability resonates strongly in communities that value responsible food choices.
+
+## Social Media’s Role in Sourdough’s Rise
+
+The visual appeal of crusty, scored loaves is undeniable. Platforms like Instagram and TikTok are filled with close-up crumb shots and time-lapse videos of dough rising. During the pandemic, many people took up home baking, sharing successes and failures online. This digital exposure demystified sourdough for a new generation of cooks. Even as normal routines resumed, interest remained high thanks to these online communities, which continue to celebrate the craft and inspire others to join in.
+
+## Final Thoughts
+
+Artisan sourdough’s growing popularity is the result of multiple converging trends: an appreciation of traditional techniques, perceived health advantages, complex flavor, a sense of community, sustainable sourcing, and social media inspiration. Each loaf represents hours—sometimes days—of attentive preparation. It embodies the slower rhythms many crave in a fast-paced world. In Yuma and beyond, sourdough captures the spirit of craftsmanship and connection, turning a humble ingredient list of flour, water, and salt into a culinary experience that draws people together.
+
+The next time you bite into a slice of tangy, chewy sourdough, consider the story behind it. From the microscopic yeast that leavened the dough to the baker’s hands that shaped the loaf, you’re participating in a tradition that stretches back centuries. As more people discover the magic of artisan sourdough, its popularity will continue to rise—proof that good things truly come to those who take the time to let them develop.
+
+As local bakeries continue to innovate, expect to see new flavor combinations and grain varieties that push sourdough in exciting directions. Workshops and community bake days will further cement its role in Yuma’s food culture. Whether you’re a lifelong bread lover or just curious about the hype, there’s never been a better time to try artisan sourdough. Pair it with your favorite spreads, share it with friends, and celebrate the craftsmanship that turns a few simple ingredients into something truly memorable.


### PR DESCRIPTION
## Summary
- add Python script `generate_blog.py` for compiling markdown posts
- author first two blog posts with frontmatter and images
- generate static HTML for posts and blog index

## Testing
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_683b9f9e8818832799308b11ce3158fc